### PR TITLE
Separate evaluation config

### DIFF
--- a/.env.evaluation.example
+++ b/.env.evaluation.example
@@ -1,0 +1,17 @@
+# Evaluation Environment Configuration Example
+
+# Langfuse credentials (shared with the main application)
+LANGFUSE_PUBLIC_KEY="your-langfuse-public-key"
+LANGFUSE_SECRET_KEY="your-langfuse-secret-key"
+LANGFUSE_HOST=https://cloud.langfuse.com
+
+# LLM settings for evaluation
+EVALUATION_LLM=gpt-4o-mini
+EVALUATION_BASE_URL=https://api.openai.com/v1
+EVALUATION_API_KEY="your-llm-api-key"
+EVALUATION_SLEEP_TIME=10
+
+# Logging configuration for evaluation
+EVAL_LOG_LEVEL=INFO
+EVAL_LOG_FORMAT=console
+EVAL_LOG_DIR=eval_logs

--- a/evals/config.py
+++ b/evals/config.py
@@ -1,0 +1,39 @@
+"""Configuration for the evaluation utilities."""
+
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+
+def load_env_file() -> None:
+    """Load environment variables from `.env.evaluation` if present."""
+    env_file = os.getenv("EVAL_ENV_FILE", ".env.evaluation")
+    if os.path.isfile(env_file):
+        load_dotenv(env_file)
+
+
+load_env_file()
+
+
+class EvalSettings:
+    """Settings used by the evaluation scripts."""
+
+    def __init__(self) -> None:
+        """Initialize evaluation settings from environment variables."""
+        self.EVALUATION_LLM = os.getenv("EVALUATION_LLM", "gpt-4o-mini")
+        self.EVALUATION_BASE_URL = os.getenv("EVALUATION_BASE_URL", "https://api.openai.com/v1")
+        self.EVALUATION_API_KEY = os.getenv("EVALUATION_API_KEY", "")
+        self.EVALUATION_SLEEP_TIME = int(os.getenv("EVALUATION_SLEEP_TIME", "10"))
+
+        # Shared Langfuse credentials
+        self.LANGFUSE_PUBLIC_KEY = os.getenv("LANGFUSE_PUBLIC_KEY", "")
+        self.LANGFUSE_SECRET_KEY = os.getenv("LANGFUSE_SECRET_KEY", "")
+        self.LANGFUSE_HOST = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
+
+        # Logging configuration
+        self.LOG_LEVEL = os.getenv("EVAL_LOG_LEVEL", "INFO")
+        self.LOG_FORMAT = os.getenv("EVAL_LOG_FORMAT", "console")
+        self.LOG_DIR = Path(os.getenv("EVAL_LOG_DIR", "logs"))
+
+
+settings = EvalSettings()

--- a/evals/evaluator.py
+++ b/evals/evaluator.py
@@ -15,10 +15,8 @@ from langfuse import Langfuse
 from langfuse.api.resources.commons.types.trace_with_details import TraceWithDetails
 from tqdm import tqdm
 
-# Fix import path for app module
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from app.core.config import settings
-from app.core.logging import logger
+from evals.config import settings
+from evals.logging import logger
 from evals.helpers import (
     calculate_avg_scores,
     generate_report,

--- a/evals/helpers.py
+++ b/evals/helpers.py
@@ -14,7 +14,7 @@ from typing import (
 
 from langfuse.api.resources.commons.types.trace_with_details import TraceWithDetails
 
-from app.core.logging import logger
+from evals.logging import logger
 from evals.schemas import ScoreSchema
 
 

--- a/evals/logging.py
+++ b/evals/logging.py
@@ -1,0 +1,67 @@
+"""Logging utilities for the evaluation scripts."""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+
+from evals.config import settings
+
+# Ensure log directory exists
+settings.LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _get_log_file_path() -> Path:
+    """Return the path to today's log file."""
+    return settings.LOG_DIR / f"evaluation-{datetime.now().strftime('%Y-%m-%d')}.jsonl"
+
+
+class JsonlFileHandler(logging.Handler):
+    """Custom handler that writes JSONL logs to a file."""
+
+    def __init__(self, file_path: Path) -> None:
+        """Create a new handler writing to *file_path*."""
+        super().__init__()
+        self.file_path = file_path
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Write a formatted log record to the file."""
+        log_entry = {
+            "timestamp": datetime.fromtimestamp(record.created).isoformat(),
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        if hasattr(record, "extra"):
+            log_entry.update(record.extra)
+        with open(self.file_path, "a", encoding="utf-8") as f:
+            f.write(structlog.processors.JSONRenderer()(None, None, log_entry) + "\n")
+
+
+def setup_logging() -> None:
+    """Configure structlog for the evaluation utilities."""
+    file_handler = JsonlFileHandler(_get_log_file_path())
+    file_handler.setLevel(settings.LOG_LEVEL)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(settings.LOG_LEVEL)
+
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.stdlib.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.processors.JSONRenderer() if settings.LOG_FORMAT == "json" else structlog.dev.ConsoleRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(getattr(logging, settings.LOG_LEVEL, logging.INFO)),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    logging.basicConfig(handlers=[file_handler, console_handler], level=settings.LOG_LEVEL, format="%(message)s")
+
+
+setup_logging()
+logger = structlog.get_logger()

--- a/evals/main.py
+++ b/evals/main.py
@@ -18,10 +18,8 @@ from colorama import (
 )
 from tqdm import tqdm
 
-# Fix import path for app module
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from app.core.config import settings
-from app.core.logging import logger
+from evals.config import settings
+from evals.logging import logger
 from evals.evaluator import Evaluator
 
 # Default configuration


### PR DESCRIPTION
## Summary
- add evaluation-only configuration and logging modules
- update evaluator imports to use new config
- update helper and CLI modules
- add example environment file for evaluations

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_684408a421848326a082acff63a9d282